### PR TITLE
save tgt vector regardless of eval option

### DIFF
--- a/bivec.c
+++ b/bivec.c
@@ -1331,6 +1331,9 @@ void TrainModel() {
 
     // Save
     SaveVector(output_prefix, src->lang, src, save_opt);
+    if (is_bi) {
+        SaveVector(output_prefix, tgt->lang, tgt, save_opt);
+    }
 
     // Eval
     if (eval_freq && cur_iter % eval_freq == 0) {
@@ -1338,7 +1341,6 @@ void TrainModel() {
       eval_mono(src->output_file, src->lang, cur_iter);
 
       if (is_bi) {
-        SaveVector(output_prefix, tgt->lang, tgt, save_opt);
         eval_mono(tgt->output_file, tgt->lang, cur_iter);
         // cldc
         cldc(output_prefix, cur_iter);


### PR DESCRIPTION
Currently, when bivec is trained without evaluation option, target vector is not saved.
This request moves the SaveVector() for target language out of the evaluation scope, so that the target vector is saved regardless of eval option.

