### PR TITLE
The presence of '<unk>' token wasn't checked correctly

### DIFF
--- a/bivec.c
+++ b/bivec.c
@@ -522,7 +522,7 @@ void LearnVocabFromTrainFile(struct train_params *params) {
   }
 
   // check <unk>
-  int unk_id = params->vocab_hash[GetWordHash(unk_word)];
+  int unk_id = SearchVocab(unk_word, params->vocab, params->vocab_hash);
   if (unk_id<0){
     fprintf(stderr, "! Can't find %s in the vocab file %s, adding ...\n", unk_word, params->train_file);
     a = AddWordToVocab(unk_word, params);


### PR DESCRIPTION
Using only GetWordHash(unk_word) to check whether the '<unk>' token is included in the vocabulary can fail if there was other token with the same hash.
Using SearchVocab() function instead solves the problem.